### PR TITLE
Link travis.com and not travis.org

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -22,7 +22,7 @@ const ciTravis = async (gh) => {
   const url = `https://travis-ci.com/${gh}.svg?branch=master`
 
   if (await badgeExists(url)) {
-    return `[![Travis CI](${url})](https://travis-ci.org/${gh})`
+    return `[![Travis CI](${url})](https://travis-ci.com/${gh})`
   } else {
     return 'N/A'
   }


### PR DESCRIPTION
This is a bug, the image is from travis.com but the link is to travis.org.