### PR TITLE
fix: correct badgen uri #10

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -19,7 +19,7 @@ const deps = (gh) => {
 }
 
 const ciTravis = async (gh) => {
-  const url = `https://flat.badgen.net/travis/${gh}.svg?branch=master`
+  const url = `https://flat.badgen.net/travis/${gh}/master`
 
   if (await badgeExists(url)) {
     return `[![Travis CI](${url})](https://travis-ci.com/${gh})`


### PR DESCRIPTION
Fixes #10 

The existing Badgen uri's would cause go-ipfs to be constructed as `https://flat.badgen.net/travis/ipfs/go-ipfs.svg?branch=master`, which yields an unknown badge: ![ci badge](https://flat.badgen.net/travis/ipfs/go-ipfs.svg?branch=master)

Fixing the uri structure to be `https://flat.badgen.net/travis/ipfs/go-ipfs/master` yields a correct badge: ![ci badge](https://flat.badgen.net/travis/ipfs/go-ipfs/master)